### PR TITLE
`companyId` support for Cloudflare

### DIFF
--- a/MoesifWorker.js
+++ b/MoesifWorker.js
@@ -29,9 +29,6 @@ if (typeof INSTALL_OPTIONS === 'undefined') {
 
 }
 
-// TODO: remove
-console.log(INSTALL_OPTIONS);
-
 let {
   appId,
   hideCreditCards,

--- a/MoesifWorker.js
+++ b/MoesifWorker.js
@@ -146,7 +146,7 @@ function headersToObject(headers) {
  * Hide anything that looks like a credit card
  * Perform a luhn check to reduce some false positives
  */
-function hideCreditCards(text) {
+function doHideCreditCards(text) {
   if (hideCreditCards) {
     return text.replace(/[0-9]{14,19}/g, (match) => {
       return luhnCheck(match)
@@ -267,7 +267,7 @@ async function makeMoesifEvent(request, response, before, after) {
         getApiVersion.name,
         undefined
       ),
-      body: hideCreditCards(requestBody),
+      body: doHideCreditCards(requestBody),
       time: before,
       uri: request.url,
       verb: request.method,

--- a/MoesifWorker.js
+++ b/MoesifWorker.js
@@ -17,14 +17,11 @@ if (typeof INSTALL_OPTIONS === 'undefined') {
     // only used by default identifyUser() implementation
     "userIdHeader": "",
 
-    // only used by default getSessionToken() implementation
-    "userSessionTokenHeader": "",
-
     // only used by default identifyUser() implementation
     "companyIdHeader": "",
 
     // only used by default getSessionToken() implementation
-    "companySessionTokenHeader": "",
+    "sessionTokenHeader": "",
 
     // true or false
     "hideCreditCards": true
@@ -38,7 +35,7 @@ console.log(INSTALL_OPTIONS);
 let {
   appId,
   hideCreditCards,
-  userSessionTokenHeader,
+  sessionTokenHeader,
   userIdHeader,
   urlPatterns = []
 } = INSTALL_OPTIONS;
@@ -71,21 +68,25 @@ const identifyUser = (req, res) => {
   return req.headers.get(userIdHeader) || res.headers.get(userIdHeader);
 };
 
+const identifyCompany = (req, res) => {
+  return req.headers.get(companyIdHeader) || res.headers.get(companyIdHeader);
+};
+
 const getSessionToken = (req, res) => {
-  return req.headers.get(userSessionTokenHeader) || res.headers.get(userSessionTokenHeader);
+  return req.headers.get(sessionTokenHeader) || res.headers.get(sessionTokenHeader);
 };
 
 const getApiVersion = (req, res) => {
   return undefined;
-}
+};
 
 const getMetadata = (req, res) => {
   return undefined;
-}
+};
 
 const skip = (req, res) => {
   return false;
-}
+};
 
 const maskContent = moesifEvent => {
   return moesifEvent;
@@ -239,6 +240,12 @@ async function makeMoesifEvent(request, response, before, after) {
     userId: runHook(
       () => identifyUser(request, response),
       identifyUser.name,
+      undefined
+    ),
+
+    companyId: runHook(
+      () => identifyCompany(request, response),
+      identifyCompany.name,
       undefined
     ),
 

--- a/MoesifWorker.js
+++ b/MoesifWorker.js
@@ -37,6 +37,7 @@ let {
   hideCreditCards,
   sessionTokenHeader,
   userIdHeader,
+  companyIdHeader,
   urlPatterns = []
 } = INSTALL_OPTIONS;
 
@@ -279,7 +280,7 @@ async function makeMoesifEvent(request, response, before, after) {
     },
     response: {
       time: after,
-      body: hideCreditCards(responseBody),
+      body: doHideCreditCards(responseBody),
       status: response.status,
       headers: {
         ...headersToObject(response.headers),

--- a/MoesifWorker.js
+++ b/MoesifWorker.js
@@ -26,7 +26,6 @@ if (typeof INSTALL_OPTIONS === 'undefined') {
     // true or false
     "hideCreditCards": true
   };
-
 }
 
 let {

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ automatically retrieve the userId without this, this is highly recommended to en
 ```javascript
 const identifyUser = (req, res) => {
   // your code here, must return a string
-  return req.user.id
+  return req.user.id;
 };
 ```
 
@@ -98,6 +98,21 @@ getSessionToken a function that takes `req` and `res` arguments and returns a se
 const getSessionToken = (req, res) => {
   // your code here, must return a string.
   return req.headers.get('Authorization');
+};
+```
+
+#### __`identifyCompany`__
+
+Type: `(Request, Response) => String`
+identifyCompany is a function that takes `req` and `res` as arguments
+and returns a companyId. This helps us attribute requests to unique companies. Even though Moesif can
+automatically retrieve the companyId without this, this is highly recommended to ensure accurate attribution.
+
+
+```javascript
+const identifyCompany = (req, res) => {
+  // your code here, must return a string
+  return req.company.id;
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,23 +21,48 @@ This option provides the most flexibility, allowing you to write custom logic to
 - Click the `Routes` tab and create a route under `Script enabled at:`. We suggest a pattern that matches all requests for your domain. Eg: If your domain is `foo.com`, **your pattern should be** `*foo.com/*`. This will match all requests to `foo.com` and any subdomains of `foo.com`.
 - Click the `Script` tab, and replace the editor content with the latest version of the [Moesif Cloudflare worker](https://raw.githubusercontent.com/Moesif/moesif-cloudflare/master/MoesifWorker.js).
 - replace any instances of the `INSTALL_OPTIONS` variable with desired values.
+- update the `INSTALL_OPTIONS` declaration with the desired values.
 
 For example:
 
 ```javascript
-const applicationId = INSTALL_OPTIONS.appId;
-const HIDE_CREDIT_CARDS = INSTALL_OPTIONS.hideCreditCards;
-const sessionTokenHeader = INSTALL_OPTIONS.sessionTokenHeader;
-const userIdHeader = INSTALL_OPTIONS.userIdHeader;
+INSTALL_OPTIONS = {
+  // your moesif App Id
+  "appId": "",
+
+  // only used by default identifyUser() implementation
+  "userIdHeader": "",
+
+  // only used by default identifyUser() implementation
+  "companyIdHeader": "",
+
+  // only used by default getSessionToken() implementation
+  "sessionTokenHeader": "",
+
+  // true or false
+  "hideCreditCards": true
+};
 ```
 
 becomes
 
 ```javascript
-const applicationId = '<< YOUR MOESIF APPLICATION ID >>';
-const HIDE_CREDIT_CARDS = true;
-const sessionTokenHeader = 'Authorization';
-const userIdHeader = null;
+INSTALL_OPTIONS = {
+  // your moesif App Id
+  "appId": "<< YOUR MOESIF APPLICATION ID >>",
+
+  // only used by default identifyUser() implementation
+  "userIdHeader": "User-Id",
+
+  // only used by default identifyUser() implementation
+  "companyIdHeader": "",
+
+  // only used by default getSessionToken() implementation
+  "sessionTokenHeader": "Authorization",
+
+  // true or false
+  "hideCreditCards": false
+};
 ```
 
 *Please note `HIDE_CREDIT_CARDS`, `sessionTokenHeader`, and `userIdHeader` may be `null`.*

--- a/install.json
+++ b/install.json
@@ -8,36 +8,50 @@
   "options": {
     "properties": {
       "appId": {
-        "order": 1,
+        "order": 10,
         "title": "Default Moesif App Id",
         "description": "Requred, unless \"App Id Overrides\" are used",
         "type": "string",
         "default": ""
       },
       "userIdHeader": {
-        "order": 2,
-        "title": "Request / Response Header Containing User ID",
+        "order": 20,
+        "title": "Request / Response Header to Identify User",
+        "description": "Optional<br>For more info, see <a href='https://www.moesif.com/docs/getting-started/users/'>User Profiles</a> and <a href='https://www.moesif.com/docs/getting-started/companies/'>Company Profiles</a>.",
+        "type": "string",
+        "default": ""
+      },
+      "userSessionTokenHeader": {
+        "order": 30,
+        "title": "Request / Response Header Containing Session Token to identify User",
         "description": "Optional",
         "type": "string",
         "default": ""
       },
-      "sessionTokenHeader": {
-        "order": 3,
-        "title": "Request / Response Header Containing Session Token",
+      "companyIdHeader": {
+        "order": 40,
+        "title": "Request / Response Header to Identify Company",
+        "description": "Optional",
+        "type": "string",
+        "default": ""
+      },
+      "companySessionTokenHeader": {
+        "order": 50,
+        "title": "Request / Response Header Containing Session Token to identify Company",
         "description": "Optional",
         "type": "string",
         "default": ""
       },
       "hideCreditCards": {
-        "order": 4,
+        "order": 60,
         "title": "Remove Credit Card Numbers from API Requests. Leave this enabled if your API processes credit card information.",
         "type": "boolean",
         "default": true
       },
       "urlPatterns": {
-        "order": 5,
+        "order": 70,
         "title": "App Id Overrides",
-        "description": "Advanced usage. For assistance with advanced configuration, please contact support@moesif.com. Regular expressions are evaluated in order (top to bottom), and the appId for the first matching regex will be used for a given request. To manually test your regular expressions, you can use the following JavaScript code: new RegExp(urlRegex).test(moesifAppId)",
+        "description": "Advanced usage.<br>For assistance with advanced configuration, please contact <a href='mailto:support@moesif.com'>support@moesif.com</a>. Regular expressions are evaluated in order (top to bottom), and the appId for the first matching regex will be used for a given request. <br> To manually test your regular expressions, you can use the following JavaScript code: new RegExp(urlRegex).test(moesifAppId)",
         "type": "array",
         "items": {
           "title": "Item",

--- a/install.json
+++ b/install.json
@@ -21,13 +21,6 @@
         "type": "string",
         "default": ""
       },
-      "userSessionTokenHeader": {
-        "order": 30,
-        "title": "Request / Response Header Containing Session Token to identify User",
-        "description": "Optional",
-        "type": "string",
-        "default": ""
-      },
       "companyIdHeader": {
         "order": 40,
         "title": "Request / Response Header to Identify Company",
@@ -35,9 +28,9 @@
         "type": "string",
         "default": ""
       },
-      "companySessionTokenHeader": {
+      "sessionTokenHeader": {
         "order": 50,
-        "title": "Request / Response Header Containing Session Token to identify Company",
+        "title": "Request / Response Header Containing Session Token",
         "description": "Optional",
         "type": "string",
         "default": ""


### PR DESCRIPTION
Ignore the branch name.

Adds support for specifying company ID via a header.

Slight refactor to the way we load install_options for developer experience.

Screenshot of what the setup screen will look like:
![Screen Shot 2019-03-26 at 11 34 00 AM](https://user-images.githubusercontent.com/3092315/55023950-174e5900-4fbb-11e9-8bec-78f08a71b1ad.png)
